### PR TITLE
feat: add support for neo4j transaction timeout

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -86,7 +86,7 @@ abstract class BasePartitionReader(
     try {
       if (result == null) {
         session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
-        transaction = session.beginTransaction()
+        transaction = session.beginTransaction(options.toNeo4jTransactionConfig())
 
         val queryText = query()
         val queryParams = queryParameters

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -69,6 +69,8 @@ class SchemaService(
 
   private val session: Session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
 
+  private val sessionTransactionConfig = options.toNeo4jTransactionConfig()
+
   private val cypherToSparkTypeConverter = CypherToSparkTypeConverter()
 
   private val sparkToCypherTypeConverter = SparkToCypherTypeConverter()
@@ -927,26 +929,29 @@ class SchemaService(
       Collections.emptyList()
     } else {
       session
-        .writeTransaction(new TransactionWork[util.List[java.util.Map[String, AnyRef]]] {
-          override def execute(transaction: Transaction): util.List[util.Map[String, AnyRef]] = {
-            others.size match {
-              case 1 => transaction.run(others.head).list()
-                  .asScala
-                  .map(_.asMap())
-                  .asJava
-              case _ => {
-                others
-                  .slice(0, queries.size - 1)
-                  .foreach(transaction.run)
-                val result = transaction.run(others.last).list()
-                  .asScala
-                  .map(_.asMap())
-                  .asJava
-                result
+        .writeTransaction(
+          new TransactionWork[util.List[java.util.Map[String, AnyRef]]] {
+            override def execute(transaction: Transaction): util.List[util.Map[String, AnyRef]] = {
+              others.size match {
+                case 1 => transaction.run(others.head).list()
+                    .asScala
+                    .map(_.asMap())
+                    .asJava
+                case _ => {
+                  others
+                    .slice(0, queries.size - 1)
+                    .foreach(transaction.run)
+                  val result = transaction.run(others.last).list()
+                    .asScala
+                    .map(_.asMap())
+                    .asJava
+                  result
+                }
               }
             }
-          }
-        })
+          },
+          sessionTransactionConfig
+        )
     }
   }
 

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -325,6 +325,19 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
     StreamingFrom.withCaseInsensitiveName(getParameter(STREAMING_FROM, DEFAULT_STREAMING_FROM.toString)),
     getParameter(STREAMING_QUERY_OFFSET)
   )
+
+  def toNeo4jTransactionConfig(): TransactionConfig = {
+    val timeout = getParameter(TRANSACTION_TIMEOUT_MSECS, DEFAULT_TRANSACTION_TIMEOUT_MSECS.toString).toInt
+
+    val builder = TransactionConfig.builder()
+    if (timeout > 0) {
+      val duration = Duration.ofMillis(timeout)
+      builder.withTimeout(duration)
+    }
+
+    builder.build()
+  }
+
 }
 
 case class Neo4jStreamingOptions(
@@ -518,6 +531,7 @@ object Neo4jOptions {
   val CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS = "connection.liveness.timeout.msecs"
   val CONNECTION_ACQUISITION_TIMEOUT_MSECS = "connection.acquisition.timeout.msecs"
   val CONNECTION_TIMEOUT_MSECS = "connection.timeout.msecs"
+  val TRANSACTION_TIMEOUT_MSECS = "db.transaction.timeout"
 
   // session options
   val DATABASE = "database"
@@ -597,6 +611,7 @@ object Neo4jOptions {
   val DEFAULT_BATCH_SIZE = 5000
   val DEFAULT_TRANSACTION_RETRIES = 3
   val DEFAULT_TRANSACTION_RETRY_TIMEOUT = 0
+  val DEFAULT_TRANSACTION_TIMEOUT_MSECS = 0
   val DEFAULT_RELATIONSHIP_NODES_MAP = false
   val DEFAULT_SCHEMA_STRATEGY = SchemaStrategy.SAMPLE
   val DEFAULT_SCHEMA_OPTIMIZATION_NODE_KEY = ConstraintsOptimizationType.NONE

--- a/common/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
+++ b/common/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
@@ -85,7 +85,7 @@ abstract class BaseDataWriter(
         session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
       }
       if (transaction == null || !transaction.isOpen) {
-        transaction = session.beginTransaction()
+        transaction = session.beginTransaction(options.toNeo4jTransactionConfig())
       }
       log.info(
         s"""Writing a batch of ${batch.size()} elements to Neo4j,

--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -22,6 +22,7 @@ import org.neo4j.driver.AccessMode
 import org.neo4j.driver.net.ServerAddress
 
 import java.net.URI
+import java.time.Duration
 
 import scala.annotation.meta.getter
 import scala.collection.JavaConverters._
@@ -241,5 +242,36 @@ class Neo4jOptionsTest {
       ).asJava,
       neo4jOptions.gdsMetadata.parameters
     )
+  }
+
+  @Test
+  def testTransactionTimeout(): Unit = {
+    // Given a Neo4j options with transaction timeout set
+    val rawOptions = new java.util.HashMap[String, String]()
+    rawOptions.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
+    rawOptions.put("db.transaction.timeout", "1000")
+
+    val neo4jOptions = new Neo4jOptions(rawOptions)
+
+    // When it converts to TransactionConfig
+    val transactionConfig = neo4jOptions.toNeo4jTransactionConfig()
+
+    // Then it has the correct duration
+    assertEquals(Duration.ofMillis(1000), transactionConfig.timeout())
+  }
+
+  @Test
+  def testDefaultTransactionTimeout(): Unit = {
+    // Given a Neo4j options with no explicit transaction timeout set
+    val rawOptions = new java.util.HashMap[String, String]()
+    rawOptions.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
+
+    val neo4jOptions = new Neo4jOptions(rawOptions)
+
+    // When it converts to TransactionConfig
+    val transactionConfig = neo4jOptions.toNeo4jTransactionConfig()
+
+    // Then it is not set
+    assertNull(transactionConfig.timeout())
   }
 }


### PR DESCRIPTION
## Feature
- Expose `neo4j.db.transaction.timeout` to Spark connector configuration
- Update schema service writeTransaction to include timeout if set
- Update partition and data writers readTransaction to include timeout if set